### PR TITLE
fix EverDrive GB X3 support, somehow

### DIFF
--- a/src/gb/everdrivex/diskio.c
+++ b/src/gb/everdrivex/diskio.c
@@ -96,7 +96,7 @@ static uint8_t send_cmd (
 /* Initialize Disk Drive                                                 */
 /*-----------------------------------------------------------------------*/
 
-uint32_t CachedSector = 0xffffffff;
+uint32_t CachedSector;
 uint8_t SectorCache[512];
 
 DSTATUS disk_initialize (void)

--- a/src/gb/ezflashjr/diskio.c
+++ b/src/gb/ezflashjr/diskio.c
@@ -8,7 +8,7 @@
 #include "diskio.h"
 #include "ezflashjr.h"
 
-uint32_t CachedSector = 0xffffffff;
+uint32_t CachedSector;
 
 inline void ezjr_unlock(void) {
     EZJR_REG_UNLOCK1 = EZJR_UNLOCK1;

--- a/src/gb/vgm_player.c
+++ b/src/gb/vgm_player.c
@@ -20,7 +20,11 @@ uint8_t *play_load;
 
 uint8_t load_buffer[LOAD_BUFFER_SIZE];
 uint8_t * load_ptr;
+#if LOAD_BUFFER_SIZE > 255
 uint16_t bytes_loaded;
+#else
+uint8_t bytes_loaded;
+#endif
 
 inline void read_init(void) {
     load_ptr = load_buffer; bytes_loaded = 0;


### PR DESCRIPTION
I don't know why this fixes it? I wonder if the issue has something to with the location of disk/SPI access code, so changing code generation can read to erratic crashes.